### PR TITLE
Support for Number=A in INFO

### DIFF
--- a/vcf.py
+++ b/vcf.py
@@ -119,7 +119,7 @@ class _vcf_metadata_parser(object):
         self.aggro = aggressive
         self.info_pattern = re.compile(r'''\#\#INFO=<
             ID=(?P<id>[^,]+),
-            Number=(?P<number>\d+|\.),
+            Number=(?P<number>\d+|\.|[AG]),
             Type=(?P<type>Integer|Float|Flag|Character|String),
             Description="(?P<desc>[^"]*)"
             >''', re.VERBOSE)
@@ -129,7 +129,7 @@ class _vcf_metadata_parser(object):
             >''', re.VERBOSE)
         self.format_pattern = re.compile(r'''\#\#FORMAT=<
             ID=(?P<id>.+),
-            Number=(?P<number>\d+|\.),
+            Number=(?P<number>\d+|\.|[AG]),
             Type=(?P<type>.+),
             Description="(?P<desc>.*)"
             >''', re.VERBOSE)
@@ -431,6 +431,7 @@ def main():
         ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
         ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
         ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+        ##INFO=<ID=AC,Number=A,Type=Integer,Description="Total number of alternate alleles in called genotypes">
         ##FILTER=<ID=q10,Description="Quality below 10">
         ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
         ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/vcf.py
+++ b/vcf.py
@@ -361,7 +361,7 @@ class VCFReader(object):
                     entry_type = self.formats[fmt].type
                 except KeyError:
                     try:
-                        entry_type = RESERVED_FORMATs[fmt]
+                        entry_type = RESERVED_FORMAT[fmt]
                     except KeyError:
                         entry_type = 'String'
 
@@ -389,7 +389,7 @@ class VCFReader(object):
 
         if row[2] != '.':
             ID = row[2]
-        else: 
+        else:
             ID = None if self.aggro else row[2]
 
         ref = row[3]


### PR DESCRIPTION
http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41
Says:

```
The Number entry is an Integer that describes the number of values that can be included with the INFO field. 
For example, if the INFO field contains a single number, then this value should be 1; if the INFO field describes
 a pair of numbers, then this value should be 2 and so on. If the field has one value per alternate allele then this
 value should be 'A'; if the field has one value for each possible genotype (more relevant to the FORMAT tags)
 then this value should be 'G'.  If the number of possible values varies, is unknown, or is unbounded, then this 
value should be '.'. 
```

This is addressed in this commit along with a misspelling of `RESERVED_FORMAT`
